### PR TITLE
Fix myInfo editing flow

### DIFF
--- a/src/main/java/com/jungook/zerotodeploy/myInfo/MyInfoController.java
+++ b/src/main/java/com/jungook/zerotodeploy/myInfo/MyInfoController.java
@@ -39,8 +39,9 @@ public class MyInfoController {
 		JoinUserEntity user = joinUserRepo.findByUserName(userName)
 				.orElseThrow(() -> new UsernameNotFoundException("not found user: " + userName));
 
-		model.addAttribute("user", user);
-		return "myInfo";
+                model.addAttribute("user", user);
+                model.addAttribute("isEditable", true);
+                return "myInfo";
 	}
 
 	@PostMapping("/uploadProfile")

--- a/src/main/resources/templates/common.html
+++ b/src/main/resources/templates/common.html
@@ -54,7 +54,7 @@
                 </div>
 
                 <div sec:authorize="isAuthenticated()">
-                    <a th:href="@{/myInfo}" class="btn btn-outline-success d-flex align-items-center justify-content-center" style="height: 42px;">내정보</a>
+                    <a th:href="@{'/api/user/myInfo/' + ${#authentication.name}}" class="btn btn-outline-success d-flex align-items-center justify-content-center" style="height: 42px;">내정보</a>
                 </div>
 
                 <div sec:authorize="isAuthenticated()" id="session-info" class="d-flex align-items-center border rounded px-3 py-1" style="font-size: 14px; color: #666; height: 42px;">


### PR DESCRIPTION
## Summary
- show `내정보` link to the correct user info page
- allow editing when accessing `/myInfo` directly

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68401d2994b88323bdf11c69992866f7