### PR TITLE
Fix missing runtime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,11 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+        implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+        implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
+        // Explicit logging dependency to ensure logback classes are packaged
+        implementation 'ch.qos.logback:logback-classic:1.4.14'
 
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/jungook/zerotodeploy/like/LikeEntity.java
+++ b/src/main/java/com/jungook/zerotodeploy/like/LikeEntity.java
@@ -1,6 +1,5 @@
 package com.jungook.zerotodeploy.like;
 
-import ch.qos.logback.core.joran.spi.HttpUtil;
 import com.jungook.zerotodeploy.joinMember.JoinUserEntity;
 import com.jungook.zerotodeploy.post.PostEntity;
 import jakarta.persistence.*;


### PR DESCRIPTION
## Summary
- ensure logback is packaged by explicitly adding logback-classic
- remove an unused logback import from `LikeEntity`

## Testing
- `gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68406a225db88323ad1b9caf2cde9858