### PR TITLE
Update README for building and running

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # ZeroToDeploy
+
+This project uses Gradle with the provided wrapper and requires **JDK 21**.
+
+## Building
+
+Use the Gradle wrapper to build the executable jar:
+
+```bash
+./gradlew bootJar
+```
+
+The jar will be created at `build/libs/ROOT.jar`.
+
+## Running
+
+Run the jar with Java:
+
+```bash
+java -jar build/libs/ROOT.jar
+```
+
+If you need to run the command with `sudo` and redirect output to a file, wrap it in `sudo bash -c`:
+
+```bash
+sudo bash -c 'java -jar build/libs/ROOT.jar > /path/to/app.log 2>&1 &'
+```


### PR DESCRIPTION
## Summary
- explain prerequisites for Gradle wrapper and JDK 21
- show how to build the jar
- document how to run the jar and how to redirect output with sudo

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684071fcae0c8323a1e595eca8b9b755