### PR TITLE
Fix logback version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,7 @@ dependencies {
         implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
         implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 
-        // Explicit logging dependency to ensure logback classes are packaged
-        implementation 'ch.qos.logback:logback-classic:1.4.14'
+       // Rely on Spring Boot's managed Logback version
 
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
- rely on Spring Boot's managed Logback dependency instead of a fixed version

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6840efe25384832398eabf2aae6a1f53