### PR TITLE
Fix myInfo link mismatch after username change

### DIFF
--- a/src/main/java/com/jungook/zerotodeploy/config/GlobalPathAdvice.java
+++ b/src/main/java/com/jungook/zerotodeploy/config/GlobalPathAdvice.java
@@ -4,13 +4,33 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.security.core.Authentication;
+
+import com.jungook.zerotodeploy.joinMember.JoinUserRepo;
 
 @ControllerAdvice
 @Configuration
 public class GlobalPathAdvice {
+        private final JoinUserRepo joinUserRepo;
 
-	@ModelAttribute("currentPath")
-	public String setCurrentPath(HttpServletRequest request) {
-		return request.getRequestURI();
-	}
+        public GlobalPathAdvice(JoinUserRepo joinUserRepo) {
+                this.joinUserRepo = joinUserRepo;
+        }
+
+        @ModelAttribute("currentPath")
+        public String setCurrentPath(HttpServletRequest request) {
+                return request.getRequestURI();
+        }
+
+        @ModelAttribute("currentUserName")
+        public String currentUserName(Authentication authentication) {
+                if (authentication == null) return null;
+
+                String loginId = authentication.getName();
+
+                return joinUserRepo.findByUserName(loginId)
+                                .or(() -> joinUserRepo.findByEmail(loginId))
+                                .map(user -> user.getUserName())
+                                .orElse(loginId);
+        }
 }

--- a/src/main/resources/templates/common.html
+++ b/src/main/resources/templates/common.html
@@ -59,7 +59,7 @@
 
                 <!-- 로그인 후: 내정보 버튼 -->
                 <div sec:authorize="isAuthenticated()">
-                    <a th:href="@{'/api/user/myInfo/' + ${#authentication.name}}"
+                    <a th:href="@{'/api/user/myInfo/' + ${currentUserName}}"
                        class="btn btn-outline-success d-flex align-items-center justify-content-center"
                        style="height: 42px;">
                         내정보

--- a/src/main/resources/templates/friends.html
+++ b/src/main/resources/templates/friends.html
@@ -9,7 +9,7 @@
         <h2>친구 목록</h2>
         <div id="friend-list">
             <ul class="list-group">
-                <li class="list-group-item" th:each="friend : ${friends}" th:with="friendName=${#authentication.name == friend.sender.userName} ? ${friend.receiver.userName} : ${friend.sender.userName}">
+                <li class="list-group-item" th:each="friend : ${friends}" th:with="friendName=${currentUserName == friend.sender.userName} ? ${friend.receiver.userName} : ${friend.sender.userName}">
                     <a th:href="@{'/api/user/myInfo/' + ${friendName}}">
                         <span th:text="${friendName}"></span>
                     </a>

--- a/src/main/resources/templates/myInfo.html
+++ b/src/main/resources/templates/myInfo.html
@@ -48,8 +48,8 @@
           </div>
         </form>
 
-        <div class="mt-3" sec:authorize="isAuthenticated()" th:if="${#authentication.name} != ${user.userName}">
-          <form th:action="@{'/friends/request/' + ${user.userName}}" method="post">
+        <div class="mt-3" sec:authorize="isAuthenticated()" th:if="${currentUserName} != ${user.userName}">
+            <form th:action="@{'/friends/request/' + ${user.userName}}" method="post">
             <button type="submit" class="btn btn-outline-primary">친구추가</button>
           </form>
         </div>

--- a/src/main/resources/templates/postDetail.html
+++ b/src/main/resources/templates/postDetail.html
@@ -95,7 +95,7 @@
                               class="form-control"
                               th:text="${comment.content}"
                               readonly></textarea>
-                    <div th:if="${#authentication.name == comment.author or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
+                    <div th:if="${currentUserName == comment.author or #authorization.expression('hasRole(''ROLE_ADMIN'')')}"
                          class="d-flex gap-2">
                         <button type="button"
                                 th:id="'edit-btn-' + ${comment.id}"


### PR DESCRIPTION
## Summary
- ensure templates link to the current username
- expose `currentUserName` via new model advice

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685276f4e1d48323bb9d791e1551d39a