### PR TITLE
Fix user profile link using username

### DIFF
--- a/src/main/resources/templates/common.html
+++ b/src/main/resources/templates/common.html
@@ -27,7 +27,7 @@
             <strong th:text="${user.nickname}">닉네임</strong>
         </div>
         <p class="text-muted mb-0" th:text="'가입일: ' + ${user.joinDate}">가입일</p>
-        <a th:href="@{'/api/user/myInfo/' + ${user.userName}}" class="btn btn-sm btn-outline-primary mt-2">프로필 보기</a>
+        <a th:href="@{'/api/user/myInfo/username/' + ${user.userName}}" class="btn btn-sm btn-outline-primary mt-2">프로필 보기</a>
     </div>
 </div>
 
@@ -59,7 +59,7 @@
 
                 <!-- 로그인 후: 내정보 버튼 -->
                 <div sec:authorize="isAuthenticated()">
-                    <a th:href="@{'/api/user/myInfo/' + ${currentUserName}}"
+                    <a th:href="@{'/api/user/myInfo/username/' + ${currentUserName}}"
                        class="btn btn-outline-success d-flex align-items-center justify-content-center"
                        style="height: 42px;">
                         내정보

--- a/src/main/resources/templates/postDetail.html
+++ b/src/main/resources/templates/postDetail.html
@@ -77,7 +77,7 @@
 
                 <p>
                     <strong>
-                        <a th:href="@{/api/user/myInfo/{username}(username=${comment.author})}">
+                        <a th:href="@{/api/user/myInfo/username/{username}(username=${comment.author})}">
                             <span
                                     class="user-popup-trigger text-primary"
                                     style="cursor: pointer;"


### PR DESCRIPTION
## Summary
- add new endpoint to view profile by username
- update templates to use `username` path for profile links

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68653ad40a9c832396c71de71fa7f218