### PR TITLE
Fix friend request path using user id

### DIFF
--- a/src/main/java/com/jungook/zerotodeploy/friends/FriendsController.java
+++ b/src/main/java/com/jungook/zerotodeploy/friends/FriendsController.java
@@ -25,9 +25,9 @@ public class FriendsController {
         return "friends";
     }
 
-    @PostMapping("/request/{username}")
-    public String sendRequest(@PathVariable String username, Authentication authentication) {
-        friendsService.sendFriendRequest(authentication.getName(), username);
+    @PostMapping("/request/{id}")
+    public String sendRequest(@PathVariable("id") Long id, Authentication authentication) {
+        friendsService.sendFriendRequest(authentication.getName(), id);
         return "redirect:/friends";
     }
 

--- a/src/main/java/com/jungook/zerotodeploy/friends/FriendsService.java
+++ b/src/main/java/com/jungook/zerotodeploy/friends/FriendsService.java
@@ -15,9 +15,11 @@ public class FriendsService {
     private final FriendsRepo friendsRepo;
     private final JoinUserRepo joinUserRepo;
 
-    public void sendFriendRequest(String senderUsername, String receiverUsername) {
-        JoinUserEntity sender = joinUserRepo.findByUserName(senderUsername).orElseThrow(() -> new UsernameNotFoundException("senderUsername :: " + senderUsername + " not found"));
-        JoinUserEntity receiver = joinUserRepo.findByUserName(receiverUsername).orElseThrow(() -> new UsernameNotFoundException("receiverUsername :: " + receiverUsername + " not found"));
+    public void sendFriendRequest(String senderUsername, Long receiverId) {
+        JoinUserEntity sender = joinUserRepo.findByUserName(senderUsername)
+                .orElseThrow(() -> new UsernameNotFoundException("senderUsername :: " + senderUsername + " not found"));
+        JoinUserEntity receiver = joinUserRepo.findById(receiverId)
+                .orElseThrow(() -> new UsernameNotFoundException("receiverId :: " + receiverId + " not found"));
 
         if(friendsRepo.findBySenderAndReceiver(sender, receiver).isEmpty()) {
             FriendsEntity friendsEntity = FriendsEntity


### PR DESCRIPTION
## Summary
- accept user ID for friend request endpoint
- fetch target user by ID to avoid UsernameNotFoundException during friend requests

## Testing
- `gradle test` *(fails: Plugin not found due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6873c069da508323b4ad90985fe6bfe1