### PR TITLE
Handle missing OAuth2 bean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,8 @@ dependencies {
 
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/jungook/zerotodeploy/config/SecurityConfig.java
+++ b/src/main/java/com/jungook/zerotodeploy/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.jungook.zerotodeploy.config;
 import com.jungook.zerotodeploy.oauth.PrincipalOauth2UserService;
 import com.jungook.zerotodeploy.details.CustomUserDetailsService;
 import com.jungook.zerotodeploy.joinMember.JoinUserEntity;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +31,7 @@ public class SecurityConfig {
     private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
 
     private final CustomUserDetailsService customUserDetailsService;
+    private final ObjectProvider<ClientRegistrationRepository> clientRegistrationRepositoryProvider;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -79,13 +82,16 @@ public class SecurityConfig {
                 .logoutUrl("/logout")
                 .logoutSuccessUrl("/")
                 .permitAll()
-            )
-            .oauth2Login(oauth2 -> oauth2
+            );
+
+        if (clientRegistrationRepositoryProvider.getIfAvailable() != null) {
+            http.oauth2Login(oauth2 -> oauth2
                 .loginPage("/login")
                 .userInfoEndpoint(userInfo -> userInfo
                     .userService(principalOauth2UserService)
                 )
             );
+        }
 
         return http.build();
     }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -10,3 +10,9 @@ spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.co
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 spring.security.oauth2.client.registration.kakao.client-name=kakao
 spring.security.oauth2.client.registration.kakao.registration-id=kakao
+
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/jungook/zerotodeploy/ZeroToDeployApplicationTests.java
+++ b/src/test/java/com/jungook/zerotodeploy/ZeroToDeployApplicationTests.java
@@ -2,11 +2,16 @@ package com.jungook.zerotodeploy;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+import com.jungook.zerotodeploy.chat.ChatRepo;
 
 @SpringBootTest(classes = ZeroToDeployApplication.class)
 @ActiveProfiles("test")
 class ZeroToDeployApplicationTests {
+
+    @MockBean
+    ChatRepo chatRepo;
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## Summary
- conditionally configure OAuth2 login when a `ClientRegistrationRepository` is present
- provide in-memory H2 database configuration for tests
- update test to mock ChatRepo and use H2
- add H2 as a test dependency

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886315cdac08323ab4beb1dae547e8b