### PR TITLE
Add basic chat room creation flow

### DIFF
--- a/src/main/java/com/jungook/zerotodeploy/chat/ChatController.java
+++ b/src/main/java/com/jungook/zerotodeploy/chat/ChatController.java
@@ -1,10 +1,71 @@
 package com.jungook.zerotodeploy.chat;
 
+import com.jungook.zerotodeploy.friends.FriendsEntity;
+import com.jungook.zerotodeploy.friends.FriendsService;
+import com.jungook.zerotodeploy.joinMember.JoinUserEntity;
+import com.jungook.zerotodeploy.joinMember.JoinUserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/chat")
+@RequiredArgsConstructor
 public class ChatController {
 
+    private final ChatService chatService;
+    private final FriendsService friendsService;
+    private final JoinUserRepo joinUserRepo;
+
+    @GetMapping("/room/user/{friendName}")
+    public String selectType(@PathVariable String friendName, Model model) {
+        model.addAttribute("friendUserName", friendName);
+        return "chatSelect";
+    }
+
+    @PostMapping("/room/individual/{friendName}")
+    public String createIndividual(@PathVariable String friendName, Authentication auth) {
+        ChatEntity room = chatService.findOrCreateRoom(auth.getName(), friendName);
+        return "redirect:/chat/room/" + room.getId();
+    }
+
+    @GetMapping("/room/several/{friendName}")
+    public String groupForm(@PathVariable String friendName, Authentication auth, Model model) {
+        List<FriendsEntity> relations = friendsService.getFriends(auth.getName());
+        List<JoinUserEntity> friends = relations.stream()
+                .map(rel -> rel.getSender().getUserName().equals(auth.getName()) ? rel.getReceiver() : rel.getSender())
+                .filter(user -> !user.getUserName().equals(friendName))
+                .toList();
+
+        JoinUserEntity target = joinUserRepo.findByUserName(friendName).orElseThrow();
+        model.addAttribute("targetUser", target);
+        model.addAttribute("friends", friends);
+        return "groupChatForm";
+    }
+
+    @PostMapping("/room/several")
+    public String createGroup(@RequestParam String roomName,
+                              @RequestParam List<Long> userIds,
+                              Authentication auth) {
+        Set<String> names = userIds.stream()
+                .map(id -> joinUserRepo.findById(id).orElseThrow())
+                .map(JoinUserEntity::getUserName)
+                .collect(Collectors.toSet());
+        names.add(auth.getName());
+        ChatEntity room = chatService.createGroupRoom(roomName, List.copyOf(names));
+        return "redirect:/chat/room/" + room.getId();
+    }
+
+    @GetMapping("/room/{id}")
+    public String viewRoom(@PathVariable Long id, Model model) {
+        ChatEntity room = chatService.getRoom(id);
+        model.addAttribute("chatRoomName", room.getRoomName());
+        return "chat";
+    }
 }

--- a/src/main/java/com/jungook/zerotodeploy/chat/ChatRepo.java
+++ b/src/main/java/com/jungook/zerotodeploy/chat/ChatRepo.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface ChatRepo extends JpaRepository<ChatEntity, Long> {
     Optional<ChatEntity> findByRoomKey(String roomKey);
+
+    Optional<ChatEntity> findByRoomName(String roomName);
 }

--- a/src/main/java/com/jungook/zerotodeploy/chat/ChatService.java
+++ b/src/main/java/com/jungook/zerotodeploy/chat/ChatService.java
@@ -3,12 +3,10 @@ package com.jungook.zerotodeploy.chat;
 import com.jungook.zerotodeploy.joinMember.JoinUserEntity;
 import com.jungook.zerotodeploy.joinMember.JoinUserRepo;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,7 +14,7 @@ public class ChatService {
 
     private final ChatRepo chatRepo;
 
-    private JoinUserRepo joinUserRepo;
+    private final JoinUserRepo joinUserRepo;
 
     public ChatEntity findOrCreateRoom(String user1Name, String user2Name) {
         List<String> sorted = Arrays.asList(user1Name, user2Name);
@@ -24,13 +22,26 @@ public class ChatService {
         String roomKey = sorted.get(0) + "_" + sorted.get(1);
         return chatRepo.findByRoomKey(roomKey)
                 .orElseGet(
-                        ()-> {
+                        () -> {
                             JoinUserEntity user1 = joinUserRepo.findByUserName(sorted.get(0)).orElseThrow();
                             JoinUserEntity user2 = joinUserRepo.findByUserName(sorted.get(1)).orElseThrow();
-
                             return chatRepo.save(ChatEntity.individual(roomKey, user1, user2));
                         }
                 );
+    }
+
+    public ChatEntity createGroupRoom(String roomName, List<String> userNames) {
+        return chatRepo.findByRoomName(roomName)
+                .orElseGet(() -> {
+                    Set<JoinUserEntity> users = userNames.stream()
+                            .map(name -> joinUserRepo.findByUserName(name).orElseThrow())
+                            .collect(Collectors.toSet());
+                    return chatRepo.save(ChatEntity.several(roomName, users));
+                });
+    }
+
+    public ChatEntity getRoom(Long roomId) {
+        return chatRepo.findById(roomId).orElseThrow();
     }
 
 }

--- a/src/main/resources/templates/chatSelect.html
+++ b/src/main/resources/templates/chatSelect.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{common::header}"></head>
+<body class="d-flex flex-column min-vh-100">
+<div class="container-xxl bg-white p-0 d-flex flex-column min-vh-100">
+    <div th:replace="~{common::nav}"></div>
+    <div class="container mt-5">
+        <h2 th:text="${friendUserName} + '와 채팅방 생성'">채팅방 생성</h2>
+        <div class="mt-4">
+            <form th:action="@{'/chat/room/individual/' + ${friendUserName}}" method="post" class="mb-3">
+                <button type="submit" class="btn btn-primary">1:1 채팅 시작</button>
+            </form>
+            <form th:action="@{'/chat/room/several/' + ${friendUserName}}" method="get">
+                <button type="submit" class="btn btn-secondary">1:n 채팅방 만들기</button>
+            </form>
+        </div>
+    </div>
+    <footer th:replace="~{common::footer}"></footer>
+    <div th:replace="~{common::script}"></div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/groupChatForm.html
+++ b/src/main/resources/templates/groupChatForm.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{common::header}"></head>
+<body class="d-flex flex-column min-vh-100">
+<div class="container-xxl bg-white p-0 d-flex flex-column min-vh-100">
+    <div th:replace="~{common::nav}"></div>
+    <div class="container mt-5">
+        <h2>1:n 채팅방 생성</h2>
+        <form th:action="@{/chat/room/several}" method="post">
+            <input type="hidden" name="userIds" th:value="${targetUser.id}" />
+            <div class="mb-3">
+                <label for="roomName" class="form-label">방 이름</label>
+                <input type="text" id="roomName" name="roomName" class="form-control" required />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">초대할 친구</label>
+                <div th:each="f : ${friends}" class="form-check">
+                    <input class="form-check-input" type="checkbox" name="userIds" th:id="${'friend' + f.id}" th:value="${f.id}" />
+                    <label class="form-check-label" th:for="${'friend' + f.id}" th:text="${f.userName}"></label>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary">방 만들기</button>
+        </form>
+    </div>
+    <footer th:replace="~{common::footer}"></footer>
+    <div th:replace="~{common::script}"></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support looking up chat room by name
- allow creating group chats
- build chat controller for individual and group chats
- add HTML templates to choose chat type and build a group chat

## Testing
- `sh gradlew test --no-daemon` *(fails: Execution failed for task ':test')*

------
https://chatgpt.com/codex/tasks/task_e_6888edd46c1c832393f70bb067f63322