### PR TITLE
Fix chat table mapping

### DIFF
--- a/src/main/java/com/jungook/zerotodeploy/chat/ChatEntity.java
+++ b/src/main/java/com/jungook/zerotodeploy/chat/ChatEntity.java
@@ -13,7 +13,12 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "chat_entity")
+// Use the existing `chat` table so that foreign key constraints
+// in the join table `chat_room_users` reference the correct parent table.
+// The previous table name `chat_entity` caused inserts into a different
+// table than the one referenced by the foreign key, leading to
+// `SQLIntegrityConstraintViolationException` when saving participants.
+@Table(name = "chat")
 public class ChatEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- align `ChatEntity` JPA mapping with existing `chat` table to prevent foreign key violations when saving participants

## Testing
- `./gradlew test` *(fails: SQLNonTransientConnectionException)*

------
https://chatgpt.com/codex/tasks/task_e_6890bfcdd3ec8323889b1eda3b69fc69